### PR TITLE
set workload identity annotation on kubernetes service account

### DIFF
--- a/rbac.yaml
+++ b/rbac.yaml
@@ -13,6 +13,13 @@ rules:
   - list
   - update
   - watch
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
To be able to make use of Kubernetes Workload Identity - see https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity - we need an annotation on the Kubernetes service account. This PR uses the full service account name (email) retrieved by display name to set the annotation.